### PR TITLE
Add agenttrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ The [accessibility tree](https://developer.mozilla.org/en-US/docs/Glossary/Acces
 
 ## Cost Tracking Tools
 
+- [agenttrace](https://github.com/luoyuctl/agenttrace) - Local-first TUI for AI coding-agent sessions that tracks tokens, estimated cost, cache use, retries, tool failures, latency, anomalies, health, diffs, and CI gates across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, and more. ![Stars](https://img.shields.io/github/stars/luoyuctl/agenttrace)
 - [Langfuse](https://github.com/langfuse/langfuse) - Open-source LLM observability + cost tracking. [Cost tracking docs](https://langfuse.com/docs/observability/features/token-and-cost-tracking). ![Stars](https://img.shields.io/github/stars/langfuse/langfuse)
 - [Helicone](https://github.com/Helicone/helicone) - LLM observability, 300+ models, SOC 2. [Cost tracking cookbook](https://docs.helicone.ai/guides/cookbooks/cost-tracking). **Note: [Acquired by Mintlify](https://www.helicone.ai/blog/joining-mintlify) in March 2026; maintenance mode only.** ![Stars](https://img.shields.io/github/stars/Helicone/helicone)
 - [LiteLLM](https://github.com/BerriAI/litellm) - SDK + proxy with [spend tracking](https://docs.litellm.ai/docs/proxy/cost_tracking) and [budget routing](https://docs.litellm.ai/docs/proxy/provider_budget_routing). ![Stars](https://img.shields.io/github/stars/BerriAI/litellm)


### PR DESCRIPTION
## Summary
- Add agenttrace to Cost Tracking Tools.

## Why
agenttrace is directly relevant to token-cost optimization for AI coding agents: it reads local Claude Code, Codex CLI, Gemini CLI, Aider, Cursor export, and similar sessions to surface tokens, estimated cost, cache use, retries, failures, latency, anomalies, health, diffs, and CI gates.

## Validation
- `git diff --check`