### PR TITLE
Add BudgetForge — hard per-project LLM spending limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ The [accessibility tree](https://developer.mozilla.org/en-US/docs/Glossary/Acces
 
 ## Cost Tracking Tools
 
+- [BudgetForge](https://llmbudget.maxiaworld.app) - Hard per-project spending limits for LLM API calls. Real-time cost tracking, multi-provider support (OpenAI, Anthropic, etc.), alerts when budget is exceeded. REST API + Python SDK.
 - [Langfuse](https://github.com/langfuse/langfuse) - Open-source LLM observability + cost tracking. [Cost tracking docs](https://langfuse.com/docs/observability/features/token-and-cost-tracking). ![Stars](https://img.shields.io/github/stars/langfuse/langfuse)
 - [Helicone](https://github.com/Helicone/helicone) - LLM observability, 300+ models, SOC 2. [Cost tracking cookbook](https://docs.helicone.ai/guides/cookbooks/cost-tracking). **Note: [Acquired by Mintlify](https://www.helicone.ai/blog/joining-mintlify) in March 2026; maintenance mode only.** ![Stars](https://img.shields.io/github/stars/Helicone/helicone)
 - [LiteLLM](https://github.com/BerriAI/litellm) - SDK + proxy with [spend tracking](https://docs.litellm.ai/docs/proxy/cost_tracking) and [budget routing](https://docs.litellm.ai/docs/proxy/provider_budget_routing). ![Stars](https://img.shields.io/github/stars/BerriAI/litellm)


### PR DESCRIPTION
## What

Adds [BudgetForge](https://llmbudget.maxiaworld.app) to the **Cost Tracking Tools** section.

## Why

BudgetForge is a complementary tool to cost tracking: rather than just observing costs, it enforces hard budget limits per project. When a project hits its budget, calls are blocked — preventing runaway spend.

Key features:
- Hard per-project spending caps (not just alerts — actual enforcement)
- Real-time cost tracking across providers
- Multi-provider: OpenAI, Anthropic, and others
- REST API + Python SDK for easy integration

This fits squarely in the cost tracking and cost control space that this list targets.