### PR TITLE
G-704: footnote vercel-labs/agent-browser as unmaintained + superseded

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Different browser automation approaches consume vastly different context.
 |-------|-----------|-----------|------|
 | WebFetch | ~1.5 KB (AI-summarized) | **20x better** | [Docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-fetch-tool) |
 | Playwright MCP | ~10-33 KB (accessibility tree) | Baseline | [GitHub](https://github.com/microsoft/playwright-mcp) |
-| Agent Browser | ~28 KB (accessibility tree) | Similar | [GitHub](https://github.com/vercel-labs/agent-browser) |
+| Agent Browser ⚠️ | ~28 KB (accessibility tree) | Project unmaintained 2026-05 — superseded by [browser-use](https://github.com/browser-use/browser-use) direct mode + [Playwright MCP](https://github.com/microsoft/playwright-mcp) | [GitHub](https://github.com/vercel-labs/agent-browser) |
 | Lightpanda | ~16 KB (raw markdown) | 2x better | [GitHub](https://github.com/lightpanda-io/browser) |
 
 For 10-page workflows: WebFetch = ~15KB vs Playwright = ~330KB total context consumed.

--- a/research/tools-and-libraries.md
+++ b/research/tools-and-libraries.md
@@ -78,7 +78,7 @@ Open source tools for cost tracking, routing, compression, and inference optimiz
 |------|-----------|-------------|------|
 | WebFetch | ~1.5KB | AI-summarized, 20x more efficient | [Docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-fetch-tool) |
 | Playwright MCP | ~33KB | Accessibility tree snapshots | [GitHub](https://github.com/microsoft/playwright-mcp) |
-| Agent Browser | ~28KB | Rust CLI, full Chromium | [GitHub](https://github.com/vercel-labs/agent-browser) |
+| Agent Browser ⚠️ | ~28KB | Rust CLI, full Chromium — **project unmaintained 2026-05; superseded by [browser-use](https://github.com/browser-use/browser-use) direct mode + [Playwright MCP](https://github.com/microsoft/playwright-mcp)** | [GitHub](https://github.com/vercel-labs/agent-browser) |
 | Lightpanda | ~16KB | Zig browser, 1.8s/page | [GitHub](https://github.com/lightpanda-io/browser) |
 | browser-use | - | Foundation library for AI browser agents | [GitHub](https://github.com/browser-use/browser-use) |
 


### PR DESCRIPTION
## Summary

Vercel-labs/agent-browser was removed from the stack (terminal-craft G-687) — repo abandoned, no first-party MCP, no commits in 6+ months. Listing it without a footnote misleads readers.

Adds ⚠️ marker + inline note to both:
- `README.md` Browser Tool Efficiency table
- `research/tools-and-libraries.md` Browser Tools table

Note points to **browser-use direct mode** and **Playwright MCP** as the 2026-05 successors. Entry kept visible (preserves awesome-list discoverability + history) but flagged.

## Test plan

- [x] Both tables render correctly in markdown preview
- [x] Successor links resolve (browser-use, Playwright MCP)
- [x] Lightpanda + browser-use entries unchanged (still accurate per 2026-05 verdicts)
- [x] Pre-merge review: docs-only, no security concerns

Closes G-704. Tracked under parent G-702 (terminal-craft G-688 propagation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)