### PR TITLE
Add Future AGI traceAI for token/latency observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ The [accessibility tree](https://developer.mozilla.org/en-US/docs/Glossary/Acces
 - [tiktoken](https://github.com/openai/tiktoken) - OpenAI's fast BPE tokenizer (Python/Rust), 3-6x faster.
 - [LangSmith Cost Tracking](https://docs.langchain.com/langsmith/cost-tracking) - Automatic recording with dashboards.
 - [LlamaIndex Cost Analysis](https://docs.llamaindex.ai/en/stable/understanding/evaluating/cost_analysis/) - Estimate costs before calls.
+- [traceAI](https://github.com/future-agi/traceAI) - Open-source OpenTelemetry-native tracing for LLM and agent apps with 50+ framework integrations, including span-level token and cost capture. ![Stars](https://img.shields.io/github/stars/future-agi/traceAI)
 
 ## Pricing Comparison
 


### PR DESCRIPTION
This PR adds open-source Future AGI projects to the most relevant section(s) of the list.

All entries are Apache 2.0 licensed and actively maintained.

- Future AGI (umbrella, 1k+ stars): https://github.com/future-agi/future-agi
- traceAI (200+ stars): https://github.com/future-agi/traceAI
- ai-evaluation (100+ stars): https://github.com/future-agi/ai-evaluation
- agent-opt: https://github.com/future-agi/agent-opt
- simulate-sdk: https://github.com/future-agi/simulate-sdk
- agent-command-center-sdk: https://github.com/future-agi/agent-command-center-sdk
- futureagi-mcp-server: https://github.com/future-agi/futureagi-mcp-server

Description style and placement match the existing entries in the chosen section(s). Single-purpose diff.