### PR TITLE
Add maintenance automation: CI lint + SessionStart hook + research rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v node >/dev/null 2>&1 || echo 'node not found — install Node 20+ to run awesome-lint'; (npx --yes awesome-lint --help >/dev/null 2>&1 &) ; echo 'This repo is an Awesome list. Before committing or opening a PR: run `npx prettier --write README.md` then `npx awesome-lint` and ensure 0 errors. See CLAUDE.md for the maintenance + verification rules.'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  awesome-lint:
+    name: awesome-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      # Keep README.md formatted (aligned tables) and Awesome-compliant.
+      - name: Check formatting
+        run: npx --yes prettier@latest --check "README.md"
+      - name: awesome-lint
+        run: npx --yes awesome-lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# Repository Guide — Awesome LLM Token Optimization
+
+This repo is a **curated Awesome list**; the deliverable is `README.md`. Keep it
+high-signal, accurate, and `awesome-lint`-clean. These rules apply to every
+session — **especially the scheduled weekly-maintenance runs**.
+
+## Hard rules
+
+1. **Lint must pass before any commit/PR.** Run `npx prettier --write README.md`
+   then `npx awesome-lint`; fix every error (0 errors). Key constraints
+   `awesome-lint` enforces:
+   - **No duplicate links** — a given URL may appear only **once** in the whole
+     README. Don't repeat a link between the Quick Wins table, inline lists, and
+     the Academic Papers tables. Papers live **only** in the Academic Papers
+     tables.
+   - **Aligned tables** (prettier handles this), list-item format
+     (`[Name](url) - Description.` ending in punctuation), no inline
+     `## License` section.
+   - **Do NOT add a CI/build badge to the README** (the badge is forbidden by
+     sindresorhus/awesome even though CI for linting is fine).
+
+2. **Verify before adding — adversarially. Never add anything unconfirmed.**
+   - **Tools:** the repo exists, is **active** (recent commits), **open-source**
+     (or has a real free tier), and is specifically about reducing LLM
+     **token/cost**. One entry per project. Reject self-promotional clusters and
+     low-traction single-author projects (~<a few hundred stars) unless clearly
+     seminal.
+   - **Papers:** the arXiv ID must resolve to the claimed title — corroborate
+     via search / Semantic Scholar / HF if `arxiv.org` blocks automated fetches.
+     **Never add unverifiable or future-dated IDs.** Include year + a verified
+     one-line key result.
+   - **Provider / pricing / caching changes:** confirm the change was actually
+     **enacted** — not merely announced, and **not announced-then-reverted**
+     (e.g. the June-15 2026 Anthropic Agent-SDK billing change was *paused*, so
+     it must not be stated as fact). When unsure, omit. For Anthropic/Claude
+     model or pricing specifics, verify against authoritative Anthropic docs,
+     not memory.
+
+3. **Dedupe against the current README first.** Read it before proposing
+   anything; never add an entry, link, or paper that's already present. (Prior
+   maintenance runs repeatedly re-proposed the same items — don't.)
+
+4. **Honor `CONTRIBUTING.md`.** Same quality bar.
+
+## PR hygiene (scheduled maintenance)
+
+- Produce **one consolidated PR per run**. If a previous maintenance PR is still
+  open, **update/supersede it** — do not stack another near-duplicate PR.
+- Close or supersede stale maintenance PRs so they don't accumulate.
+- Branch name `maintenance/YYYY-MM-DD`; **delete the branch after merge/close**.
+- The PR body should list what was added **and what was checked but rejected,
+  with the reason** (so verification is auditable).
+
+## Weekly maintenance playbook
+
+Sweep → verify → consolidate:
+
+1. **Provider docs/pricing** (Anthropic, OpenAI, Google, DeepSeek, Mistral, xAI):
+   caching, batch, and pricing changes **actually in effect**.
+2. **New tools/frameworks** (routing, gateways, prompt/output compression,
+   KV-cache, inference engines, cost tracking) — verify per Hard Rule 2.
+3. **New papers** (compression, KV-cache, routing, context, concise reasoning) —
+   verify IDs per Hard Rule 2; add to the Academic Papers tables only.
+4. **Link health** on a sample — a 403 from a bot ≠ a dead link; confirm via a
+   browser/search before removing anything.
+5. Update README → `prettier --write` → `awesome-lint` (0 errors) → open **one**
+   PR summarizing the verified changes.


### PR DESCRIPTION
## Summary

Sets up the repo so the scheduled Claude Code web **maintenance runs are deep, verified, and self-correcting** — addressing the problems found in the prior weekly runs (PRs piling up unmerged, the same items re-proposed every week, and unverified / announced-then-reverted content slipping in).

## What's added
- **`.github/workflows/lint.yml`** — runs `prettier --check` + `awesome-lint` on every PR and push to `main`, so the list stays Awesome-compliant automatically. (No README badge — sindresorhus/awesome forbids the badge but allows the CI.)
- **`.claude/settings.json`** — a `SessionStart` hook that warms `awesome-lint` and reminds every web session to run prettier + awesome-lint and follow `CLAUDE.md`.
- **`CLAUDE.md`** — repository guide + **weekly-maintenance playbook** with the research rules every triggered run must follow:
  - Lint must pass (0 errors) before any commit/PR; no duplicate links; papers live only in the Academic Papers tables.
  - **Adversarially verify** every tool/paper/pricing change before adding — no unverifiable or future-dated arXiv IDs, no announced-then-reverted pricing (e.g. the paused June-15 Anthropic billing change).
  - Dedupe against the current README first; one consolidated PR per run; close/supersede stale PRs.

## Notes
- Local checks pass: `prettier --check README.md` ✅ and `awesome-lint` ✅ (0 real errors).
- The trigger **schedule** itself lives in the [Claude Code web dashboard](https://code.claude.com/docs/en/claude-code-on-the-web), not the repo — I can't edit that from here. `CLAUDE.md` governs what each run *does*; you may also want to point the trigger's prompt at it.
- ⚠️ **Couldn't delete the 7 stale `maintenance/*` branches** — branch deletion is blocked in this environment (HTTP 403). Please delete them via the GitHub UI (the "Delete branch" button on each closed PR, or the Branches page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBJsdVF26E7MzzEvdMvREd)_