### PR TITLE
Add llmtrim to Prompt Compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Reduce prompt size while preserving information quality.
 - [Headroom](https://github.com/chopratejas/headroom) - Compress tool outputs, logs, files, and RAG chunks before they reach the LLM (60-95% fewer tokens); library, proxy, and MCP server. Claude Code/Cursor/Aider compatible.
 - [code2prompt](https://github.com/mufeedvh/code2prompt) - Codebase to LLM prompt with token counting. ![Stars](https://img.shields.io/github/stars/mufeedvh/code2prompt)
 - [RTK](https://github.com/rtk-ai/rtk) - Single-binary Rust CLI proxy that compresses dev-command output 60-90% before it reaches a coding agent's context. Works with Claude Code, Cursor, Copilot, Gemini CLI. ![Stars](https://img.shields.io/github/stars/rtk-ai/rtk)
+- [llmtrim](https://github.com/fkiene/llmtrim) - Quality-gated MITM proxy and MCP server that compresses prompts, tool outputs, and replies before they reach the LLM, reverting any step that does not save (measured -31% input / -74% output across live A/B cases). Rust CLI plus library bindings and a WASM/JS package. ![Stars](https://img.shields.io/github/stars/fkiene/llmtrim)
 
 ### Research
 


### PR DESCRIPTION
Adds [llmtrim](https://github.com/fkiene/llmtrim) under **Prompt Compression > Tools**, alongside RTK and Headroom.

llmtrim is a quality-gated proxy and MCP server that compresses prompts, tool outputs, and replies before they reach the LLM; any step that does not save tokens is reverted, so it never increases the bill. Measured -31% input and -74% output tokens across 112 live A/B cases. Same shape as the listed RTK and Headroom (proxy + MCP + compression), plus a Rust CLI, library bindings (Rust/Python/Ruby/Swift/Kotlin), and a WASM/JS npm package. Open source, MPL-2.0.