### PR TITLE
Add llmtrim to Prompt Compression > Tools (preserves @fkiene's authorship)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Reduce prompt size while preserving information quality.
 - [code2prompt](https://github.com/mufeedvh/code2prompt) - Codebase to LLM prompt with token counting. ![Stars](https://img.shields.io/github/stars/mufeedvh/code2prompt)
 - [RTK](https://github.com/rtk-ai/rtk) - Single-binary Rust CLI proxy that compresses dev-command output 60-90% before it reaches a coding agent's context. Works with Claude Code, Cursor, Copilot, Gemini CLI. ![Stars](https://img.shields.io/github/stars/rtk-ai/rtk)
 - [TOON](https://github.com/toon-format/toon) - Token-Oriented Object Notation: a compact, schema-aware encoding for passing JSON-like data to LLMs; 30-60% fewer tokens than JSON on uniform arrays of objects. ![Stars](https://img.shields.io/github/stars/toon-format/toon)
+- [llmtrim](https://github.com/fkiene/llmtrim) - Quality-gated MITM proxy and MCP server that compresses prompts, tool outputs, and replies before they reach the LLM, reverting any step that does not save (measured -31% input / -74% output across live A/B cases). Rust CLI plus library bindings and a WASM/JS package. ![Stars](https://img.shields.io/github/stars/fkiene/llmtrim)
 
 ### Research
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Reduce prompt size while preserving information quality.
 - [code2prompt](https://github.com/mufeedvh/code2prompt) - Codebase to LLM prompt with token counting. ![Stars](https://img.shields.io/github/stars/mufeedvh/code2prompt)
 - [RTK](https://github.com/rtk-ai/rtk) - Single-binary Rust CLI proxy that compresses dev-command output 60-90% before it reaches a coding agent's context. Works with Claude Code, Cursor, Copilot, Gemini CLI. ![Stars](https://img.shields.io/github/stars/rtk-ai/rtk)
 - [TOON](https://github.com/toon-format/toon) - Token-Oriented Object Notation: a compact, schema-aware encoding for passing JSON-like data to LLMs; 30-60% fewer tokens than JSON on uniform arrays of objects. ![Stars](https://img.shields.io/github/stars/toon-format/toon)
-- [llmtrim](https://github.com/fkiene/llmtrim) - Quality-gated MITM proxy and MCP server that compresses prompts, tool outputs, and replies before they reach the LLM, reverting any step that does not save (measured -31% input / -74% output across live A/B cases). Rust CLI plus library bindings and a WASM/JS package. ![Stars](https://img.shields.io/github/stars/fkiene/llmtrim)
+- [llmtrim](https://github.com/fkiene/llmtrim) - Quality-gated local proxy and MCP server that compresses prompts, tool outputs, and replies before they reach the LLM, reverting any step that doesn't save tokens (project-reported -31% input / -74% output across 112 A/B cases). Rust CLI plus multi-language library bindings and a WebAssembly/JS package. ![Stars](https://img.shields.io/github/stars/fkiene/llmtrim)
 
 ### Research
 


### PR DESCRIPTION
Brings in [`llmtrim`](https://github.com/fkiene/llmtrim) under **Prompt Compression > Tools**, reversing the earlier hold on #18.

This carries **@fkiene's original commit (authorship preserved via cherry-pick)** plus a light maintainer copy-edit, so contribution credit stays with them. Supersedes #18.

### Added
- `llmtrim` — quality-gated local proxy + MCP server that compresses prompts, tool outputs, and replies before they reach the LLM, reverting any step that doesn't save tokens. Rust CLI + multi-language bindings + WebAssembly/JS package.

### Verification (Hard Rule 2)
- ✅ Real & open source — MPL-2.0
- ✅ Active — v0.3.2 tagged 2026-06-22 (~5 days ago), 349 commits
- ✅ On-topic — directly reduces LLM token/cost
- ✅ Distinct surface — proxy + MCP + CLI + bindings; not a duplicate of any existing entry
- ✅ No duplicate link; placed in the correct section

### Copy-edit vs. the original #18 wording
- "MITM proxy" → "local proxy" (matches the project's own README framing; drops the misleading man-in-the-middle connotation)
- Headline figures attributed as **project-reported** (−31% input / −74% output across 112 A/B cases) — the same treatment the neighbouring self-measured Headroom (60-95%) and RTK (60-90%) numbers already get
- "WASM" → "WebAssembly" (awesome-lint spell-check)

### What was weighed
- The earlier hold was on the **soft traction bar** (~128★, ~3 weeks old, single-author, self-submitted), not on quality. Maintainer decision to include it as a deliberate, verified exception — it clears every hard rule, and singling out its self-reported figures held it to a stricter bar than the Headroom/RTK entries beside it.

### Lint
- `prettier --write README.md` → clean (unchanged)
- `awesome-lint` → clean on content. (The local sandbox emits one environmental `remark-lint:awesome-github` "valid git repository" error because the sandbox git remote isn't github.com; it is content-independent and passes under the Actions checkout. CI `lint.yml` runs `prettier --check` + `awesome-lint` and is the source of truth.)

To preserve @fkiene's authorship, merge with a **merge commit or rebase** (not squash).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BM5Yp3pS1nNoDFpKYx8Bxp)_