### PR TITLE
maintenance: weekly update 2026-07-05

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Reuse previously-processed prompt prefixes to avoid re-computing the same tokens
 
 ### Provider Docs
 
-- [Anthropic Prompt Caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) - 90% discount, 5min/1hr TTL. Minimum cacheable prefix: 4,096 tokens on Opus 4.6/Haiku 4.5, 1,024 on Sonnet 4.6/Opus 4.8.
+- [Anthropic Prompt Caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) - 90% discount, 5min/1hr TTL. Minimum cacheable prefix: 4,096 tokens on Opus 4.6/Haiku 4.5, 1,024 on Sonnet 4.6/Opus 4.8/Sonnet 5.
 - [Anthropic Caching Announcement](https://www.anthropic.com/news/prompt-caching) - Blog post explaining economics.
 - [Anthropic Token-Saving Updates](https://www.anthropic.com/news/token-saving-updates) - Cache-aware rate limits, simplified caching.
 - [Anthropic Extended Thinking + Caching](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking) - Thinking blocks get cached in tool-use loops.
@@ -262,19 +262,20 @@ The [accessibility tree](https://developer.mozilla.org/en-US/docs/Glossary/Acces
 - [DeepSeek Pricing](https://api-docs.deepseek.com/quick_start/pricing) - Official DeepSeek pricing.
 - [Mistral Pricing](https://mistral.ai/pricing) - Official Mistral pricing.
 
-### Notable Recent Pricing (June 2026)
+### Notable Recent Pricing (June–July 2026)
 
-| Model                 | Input /MTok | Output /MTok | Notes                                                                                                                                      |
-| --------------------- | ----------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Claude Fable 5        | $10.00      | $50.00       | Anthropic's most capable model; 1M context (June 2026). **Access suspended June 12 via US export-control directive; restoration pending.** |
-| Claude Opus 4.8       | $5.00       | $25.00       | 1M context at standard pricing                                                                                                             |
-| GPT-5.5               | $5.00       | $30.00       | OpenAI flagship; 1M context; 90% cached-input discount                                                                                     |
-| GPT-5.4               | $2.50       | $15.00       | Half the cost of GPT-5.5; 50% Batch API discount                                                                                           |
-| DeepSeek V4 Flash     | $0.14       | $0.28        | Cheapest frontier; 98% cache savings                                                                                                       |
-| DeepSeek V4 Pro       | $0.435      | $0.87        | 1M context; thinking + non-thinking modes                                                                                                  |
-| Gemini 3.1 Pro        | $2.00       | $12.00       | Preview since Feb 2026; ≤200K context; doubles to $4/$18 above 200K tokens                                                                 |
-| Gemini 3.5 Flash      | $1.50       | $9.00        | Launched May 19, 2026; 1M context window                                                                                                   |
-| Gemini 2.5 Flash-Lite | $0.10       | $0.40        | Budget option                                                                                                                              |
+| Model                 | Input /MTok | Output /MTok | Notes                                                                                                                                        |
+| --------------------- | ----------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Fable 5        | $10.00      | $50.00       | Anthropic's most capable model; 1M context (June 2026). Access suspended June 12 via US export-control directive; **restored July 1, 2026**. |
+| Claude Opus 4.8       | $5.00       | $25.00       | 1M context at standard pricing                                                                                                               |
+| Claude Sonnet 5       | $2.00       | $10.00       | Introductory pricing through Aug 31, 2026 (standard: $3/$15 per MTok); 1M context; most agentic Sonnet; launched June 30, 2026.              |
+| GPT-5.5               | $5.00       | $30.00       | OpenAI flagship; 1M context; 90% cached-input discount                                                                                       |
+| GPT-5.4               | $2.50       | $15.00       | Half the cost of GPT-5.5; 50% Batch API discount                                                                                             |
+| DeepSeek V4 Flash     | $0.14       | $0.28        | Cheapest frontier; 98% cache savings                                                                                                         |
+| DeepSeek V4 Pro       | $0.435      | $0.87        | 1M context; thinking + non-thinking modes                                                                                                    |
+| Gemini 3.1 Pro        | $2.00       | $12.00       | Preview since Feb 2026; ≤200K context; doubles to $4/$18 above 200K tokens                                                                   |
+| Gemini 3.5 Flash      | $1.50       | $9.00        | Launched May 19, 2026; 1M context window                                                                                                     |
+| Gemini 2.5 Flash-Lite | $0.10       | $0.40        | Budget option                                                                                                                                |
 
 ## Prompt Engineering for Efficiency
 
@@ -407,6 +408,7 @@ The [accessibility tree](https://developer.mozilla.org/en-US/docs/Glossary/Acces
 | [Continuous Semantic Caching](https://arxiv.org/abs/2604.20021)      | 2026 | Theory for semantic caching in continuous embedding space; dynamic ε-net + kernel ridge regression                                |
 | [Learning to Draft (LTD)](https://arxiv.org/abs/2603.01639)          | 2026 | RL co-adapts draft+verify policies to optimize true throughput, not acceptance length (ICLR 2026)                                 |
 | [DDTree (Block Diffusion)](https://arxiv.org/abs/2604.12989)         | 2026 | Block-diffusion draft tree for speculative decoding; outperforms EAGLE-3 at matched node budget                                   |
+| [Graft](https://arxiv.org/abs/2605.20104)                            | 2026 | Training-free prune-then-retrieve framework for speculative decoding draft trees; 5.41× speedup, 21.8% over EAGLE-3 on Qwen3-235B |
 
 ### Prompt Optimization
 


### PR DESCRIPTION
## Summary

Weekly maintenance sweep for 2026-07-05. All changes verified against primary sources before inclusion.

---

## Provider / Pricing Changes

**Added:**
- **Claude Sonnet 5** — new row in the pricing table. Launched June 30, 2026; introductory $2/$10 per MTok through Aug 31, 2026, then standard $3/$15. Verified via [Anthropic announcement](https://www.anthropic.com/news/claude-sonnet-5) + [Claude docs](https://platform.claude.com/docs/en/about-claude/pricing).
- **Prompt Caching section** — added `Sonnet 5` to the minimum cacheable prefix list (1,024 tokens, matching Sonnet 4.6/Opus 4.8). Verified via Anthropic prompt-caching docs and multiple corroborating sources.
- **Pricing table heading** — updated from "June 2026" to "June–July 2026" to reflect new additions.

**Updated:**
- **Claude Fable 5 note** — changed "restoration pending" to "restored July 1, 2026". Access was restored globally on July 1 following the lifting of the US export-control directive that had suspended it on June 12. Verified via Anthropic release notes and multiple news sources.

---

## New Tools

**None added.** New GitHub tools found were single-author projects with low star counts that do not meet the quality bar (e.g., `maheshmakvana/llm-token-optimizer`, `burgerkhan6227/tokenWise-Optimizer`, `alexgreensh/token-optimizer`).

---

## New Papers

**Added:**
- **[Graft](https://arxiv.org/abs/2605.20104)** (2026) — "Draft Less, Retrieve More: Hybrid Tree Construction for Speculative Decoding." Training-free prune-then-retrieve framework; 5.41× speedup, 21.8% improvement over EAGLE-3 on Qwen3-235B. Added to KV Cache & Inference table. Verified via arXiv abstract + HTML version.

**Checked but rejected:**
- `arxiv 2506.00307` "Lossless Token Sequence Compression via Meta-Tokens" — published May 2025 (not new); 27% lossless compression. Not added as it predates the current list's coverage.
- `arxiv 2604.26412` "When Hidden States Drift" — April 2026 speculative decoding paper proposing KV-Reuse Hypothesis. Verified, but the result is a hypothesis/analysis paper without a concrete efficiency number that adds clear value over papers already in the table.

---

## New Strategies

**None** — no new generalizable strategies identified beyond what is already covered.

---

## Link Health (15-link sample)

All sampled links resolve correctly:
- `github.com/montevive/autocache` — active, v1.1.1 (Feb 2026) ✓
- `github.com/bespokelabsai/curator` — active, v0.1.27 (Mar 2026) ✓
- `github.com/langfuse/langfuse` — active, v3.205.0 (Jul 3 2026) ✓
- `github.com/kvcache-ai/Mooncake` — active, v0.3.11 (May 2026) ✓
- `github.com/chroma-core/context-rot` — active ✓
- `github.com/BerriAI/litellm` — active, v1.91.0 (Jul 4 2026) ✓
- `github.com/microsoft/LLMLingua` — active, 6.4k stars ✓
- `github.com/lm-sys/RouteLLM` — still not archived, 5.1k stars (note in README re: Aug 2024 last commit already present) ✓
- `epoch.ai/data-insights/llm-inference-price-trends` — returned 403 (bot block, not dead) ✓
- `artificialanalysis.ai/leaderboards/models` — 403 from bot block, not dead ✓

**Dead links found:** None.

---

## Items Checked but Not Added (per Hard Rules)

- **GPT-5.6 family** (Sol/Terra/Luna) — in limited preview (~20 partners) as of July 5, not broadly available. Not enacted for public use. Will add when generally available.
- **DeepSeek V4 peak/off-peak pricing** — announced June 30 for mid-July formal V4 launch, but not yet enacted. Will add once the V4 formal launch goes live.
- **DeepSeek alias deprecation** (July 24, 2026) — already in the README.

---

## Verification

- `npx prettier --write README.md` — ran, no format issues
- `npx awesome-lint https://github.com/pleasedodisturb/awesome-llm-token-optimization` — **0 errors** (local proxy URL causes a false positive on the `awesome-github` rule; running against the actual GitHub URL passes clean)

---
_Generated by [Claude Code](https://claude.ai/code/session_015xRrExW2rr5yTj7dwtzxmK)_