### PR TITLE
G-1325: align Quick Wins table link labels (Lane-2 autonomous test)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ Building with LLMs is expensive. An agent processing 10 reasoning steps can cons
 
 The highest-impact strategies ranked by effort-to-savings ratio:
 
-| Strategy                 | Savings              | Effort                   | Link                            |
-| ------------------------ | -------------------- | ------------------------ | ------------------------------- |
-| Prompt caching           | 90% input tokens     | Add cache headers        | Prompt Caching                  |
+| Strategy                 | Savings              | Effort                   | Link                              |
+| ------------------------ | -------------------- | ------------------------ | --------------------------------- |
+| Prompt caching           | 90% input tokens     | Add cache headers        | Prompt Caching                    |
 | Token-efficient tool use | 70% output reduction | Flip a flag              | Prompt Engineering for Efficiency |
-| Batch API                | 50%                  | Queue non-urgent work    | Batch APIs                      |
-| Model routing            | 60-95%               | Route by task complexity | Model Routing                   |
-| Response caching         | 100% on repeats      | Add a cache layer        | Comprehensive Guides            |
-| Prompt compression       | 5-20x                | Use LLMLingua            | Prompt Compression              |
+| Batch API                | 50%                  | Queue non-urgent work    | Batch APIs                        |
+| Model routing            | 60-95%               | Route by task complexity | Model Routing                     |
+| Response caching         | 100% on repeats      | Add a cache layer        | Comprehensive Guides              |
+| Prompt compression       | 5-20x                | Use LLMLingua            | Prompt Compression                |
 
 **Combined pipeline:** Cache prefix (90%) + route to cheapest model (60-95%) + batch non-urgent (50%) + compress prompts (5-20x) + cache responses (100% on repeats) = **95-99% cost reduction** vs. naive approach.
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ Building with LLMs is expensive. An agent processing 10 reasoning steps can cons
 
 The highest-impact strategies ranked by effort-to-savings ratio:
 
-| Strategy                 | Savings              | Effort                   | Link                 |
-| ------------------------ | -------------------- | ------------------------ | -------------------- |
-| Prompt caching           | 90% input tokens     | Add cache headers        | Prompt Caching       |
-| Token-efficient tool use | 70% output reduction | Flip a flag              | Prompt Engineering   |
-| Batch API                | 50%                  | Queue non-urgent work    | Batch APIs           |
-| Model routing            | 60-95%               | Route by task complexity | Model Routing        |
-| Response caching         | 100% on repeats      | Add a cache layer        | Comprehensive Guides |
-| Prompt compression       | 5-20x                | Use LLMLingua            | Prompt Compression   |
+| Strategy                 | Savings              | Effort                   | Link                            |
+| ------------------------ | -------------------- | ------------------------ | ------------------------------- |
+| Prompt caching           | 90% input tokens     | Add cache headers        | Prompt Caching                  |
+| Token-efficient tool use | 70% output reduction | Flip a flag              | Prompt Engineering for Efficiency |
+| Batch API                | 50%                  | Queue non-urgent work    | Batch APIs                      |
+| Model routing            | 60-95%               | Route by task complexity | Model Routing                   |
+| Response caching         | 100% on repeats      | Add a cache layer        | Comprehensive Guides            |
+| Prompt compression       | 5-20x                | Use LLMLingua            | Prompt Compression              |
 
 **Combined pipeline:** Cache prefix (90%) + route to cheapest model (60-95%) + batch non-urgent (50%) + compress prompts (5-20x) + cache responses (100% on repeats) = **95-99% cost reduction** vs. naive approach.
 


### PR DESCRIPTION
**First autonomous PR from the Lane-2 build lane** — draft, for review.

Generated by **goose** running on the **free-llm-relay** (Qwen3-Coder via the local free-first LLM router, edits-only). Git + PR are human-gated; nothing merges without you.

## What it changed
- Aligned the 'Token-efficient tool use' row's Link label (`Prompt Engineering` → `Prompt Engineering for Efficiency`) to match the actual section heading, and re-padded the Quick Wins table.
- No entries/content added or removed.

## Why this exists
Proof that the autonomous build lane produces real, correct edits on free/cheap tokens for human review (G-1325). The agent hit its turn cap (`GOOSE_MAX_TURNS=20`) mid-pass, so this is a partial maintenance sweep, not exhaustive.

🤖 Autonomous draft — review before merge.