### PR TITLE
maintenance: weekly update 2026-07-19

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Reuse previously-processed prompt prefixes to avoid re-computing the same tokens
 - [Anthropic Caching Announcement](https://www.anthropic.com/news/prompt-caching) - Blog post explaining economics.
 - [Anthropic Token-Saving Updates](https://www.anthropic.com/news/token-saving-updates) - Cache-aware rate limits, simplified caching.
 - [Anthropic Extended Thinking + Caching](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking) - Thinking blocks get cached in tool-use loops.
-- [OpenAI Prompt Caching](https://platform.openai.com/docs/guides/prompt-caching) - 50% discount, automatic for 1024+ token prompts. Extended cache retention now defaults to 24h on the GPT-5 series (mandatory on GPT-5.5+), keeping prefixes warm far longer.
+- [OpenAI Prompt Caching](https://platform.openai.com/docs/guides/prompt-caching) - 50% discount on GPT-5.5 and earlier; **90% discount on GPT-5.6+** with explicit cache breakpoints and 30-minute minimum cache TTL. Cache writes billed at 1.25× the input rate on GPT-5.6+. Automatic for 1024+ token prompts.
 - [OpenAI Prompt Caching Cookbook](https://developers.openai.com/cookbook/examples/prompt_caching_201) - Advanced techniques with code.
 - [Google Gemini Context Caching](https://ai.google.dev/gemini-api/docs/caching) - Implicit (auto) and explicit caching, 90% discount.
 - [Google Vertex AI Caching](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview) - Enterprise context caching.
@@ -264,18 +264,24 @@ The [accessibility tree](https://developer.mozilla.org/en-US/docs/Glossary/Acces
 
 ### Notable Recent Pricing (June–July 2026)
 
-| Model                 | Input /MTok | Output /MTok | Notes                                                                                                                                        |
-| --------------------- | ----------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| Claude Fable 5        | $10.00      | $50.00       | Anthropic's most capable model; 1M context (June 2026). Access suspended June 12 via US export-control directive; **restored July 1, 2026**. |
-| Claude Opus 4.8       | $5.00       | $25.00       | 1M context at standard pricing                                                                                                               |
-| Claude Sonnet 5       | $2.00       | $10.00       | Introductory pricing through Aug 31, 2026 (standard: $3/$15 per MTok); 1M context; most agentic Sonnet; launched June 30, 2026.              |
-| GPT-5.5               | $5.00       | $30.00       | OpenAI flagship; 1M context; 90% cached-input discount                                                                                       |
-| GPT-5.4               | $2.50       | $15.00       | Half the cost of GPT-5.5; 50% Batch API discount                                                                                             |
-| DeepSeek V4 Flash     | $0.14       | $0.28        | Cheapest frontier; 98% cache savings                                                                                                         |
-| DeepSeek V4 Pro       | $0.435      | $0.87        | 1M context; thinking + non-thinking modes                                                                                                    |
-| Gemini 3.1 Pro        | $2.00       | $12.00       | Preview since Feb 2026; ≤200K context; doubles to $4/$18 above 200K tokens                                                                   |
-| Gemini 3.5 Flash      | $1.50       | $9.00        | Launched May 19, 2026; 1M context window                                                                                                     |
-| Gemini 2.5 Flash-Lite | $0.10       | $0.40        | Budget option                                                                                                                                |
+| Model                 | Input /MTok | Output /MTok | Notes                                                                                                                                                                                         |
+| --------------------- | ----------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Fable 5        | $10.00      | $50.00       | Anthropic's most capable model; 1M context (June 2026). Access suspended June 12 via US export-control directive; **restored July 1, 2026**. Included in subscriptions through July 19, 2026. |
+| Claude Mythos 5       | $10.00      | $50.00       | Same model as Fable 5 with safety classifiers removed; limited access via [Project Glasswing](https://www.anthropic.com/glasswing) only (~150 approved orgs).                                 |
+| Claude Opus 4.8       | $5.00       | $25.00       | 1M context at standard pricing                                                                                                                                                                |
+| Claude Sonnet 5       | $2.00       | $10.00       | Introductory pricing through Aug 31, 2026 (standard: $3/$15 per MTok); 1M context; most agentic Sonnet; launched June 30, 2026.                                                               |
+| GPT-5.6 Sol           | $5.00       | $30.00       | OpenAI flagship (GA July 9, 2026); 1.05M context; 90% cached-input discount; explicit cache breakpoints; cache writes at 1.25× input rate                                                     |
+| GPT-5.6 Terra         | $2.50       | $15.00       | Balanced tier (GA July 9, 2026); 1.05M context; same 90% cached-input discount as Sol                                                                                                         |
+| GPT-5.6 Luna          | $1.00       | $6.00        | Cost-optimized tier (GA July 9, 2026); 1.05M context; 90% cached-input discount                                                                                                               |
+| GPT-5.5               | $5.00       | $30.00       | OpenAI previous flagship; 1M context; 50% cached-input discount                                                                                                                               |
+| GPT-5.4               | $2.50       | $15.00       | Half the cost of GPT-5.5; 50% Batch API discount                                                                                                                                              |
+| DeepSeek V4 Flash     | $0.14       | $0.28        | Cheapest frontier; 98% cache savings                                                                                                                                                          |
+| DeepSeek V4 Pro       | $0.435      | $0.87        | 1M context; thinking + non-thinking modes                                                                                                                                                     |
+| Gemini 3.1 Pro        | $2.00       | $12.00       | Preview since Feb 2026; ≤200K context; doubles to $4/$18 above 200K tokens                                                                                                                    |
+| Gemini 3.5 Flash      | $1.50       | $9.00        | Launched May 19, 2026; 1M context window                                                                                                                                                      |
+| Gemini 2.5 Flash-Lite | $0.10       | $0.40        | Budget option                                                                                                                                                                                 |
+
+**Tokenizer change (Anthropic):** Claude Opus 4.7+, Sonnet 5, Fable 5, and Mythos 5 use a new tokenizer producing approximately 30% more tokens for the same text. Per-token prices are unchanged, but effective cost per fixed input rises proportionally. Benchmark your actual workload before assuming savings from upgrading models.
 
 ## Prompt Engineering for Efficiency
 
@@ -379,36 +385,40 @@ The [accessibility tree](https://developer.mozilla.org/en-US/docs/Glossary/Acces
 
 ### KV Cache & Inference
 
-| Paper                                                                | Year | Key Result                                                                                                                        |
-| -------------------------------------------------------------------- | ---- | --------------------------------------------------------------------------------------------------------------------------------- |
-| [PagedAttention (vLLM)](https://arxiv.org/abs/2309.06180)            | 2023 | Near-zero KV cache waste                                                                                                          |
-| [RadixAttention (SGLang)](https://arxiv.org/abs/2312.07104)          | 2023 | Auto KV cache reuse                                                                                                               |
-| [KV Cache Survey (2026)](https://arxiv.org/abs/2603.20397)           | 2026 | Comprehensive techniques survey                                                                                                   |
-| [VectorQ Semantic Caching](https://arxiv.org/abs/2502.03771)         | 2025 | Up to 100x latency reduction                                                                                                      |
-| [KV-Compress](https://arxiv.org/abs/2410.00161)                      | 2024 | Variable-head-rate compression                                                                                                    |
-| [vAttention](https://arxiv.org/abs/2405.04437)                       | 2024 | 1.99x throughput over vLLM                                                                                                        |
-| [LazyLLM](https://arxiv.org/abs/2407.14057)                          | 2024 | Dynamic token pruning at prefill                                                                                                  |
-| [SlimInfer](https://arxiv.org/abs/2508.06447)                        | 2025 | 1.88x latency reduction                                                                                                           |
-| [Mirror Speculative Decoding](https://arxiv.org/abs/2510.13161)      | 2025 | Breaks serial barrier                                                                                                             |
-| [LongSpec](https://arxiv.org/abs/2502.17421)                         | 2025 | Constant memory speculative decoding                                                                                              |
-| [Speculative Speculative Decoding](https://arxiv.org/abs/2603.03251) | 2026 | Parallelizes speculation+verification; 30% faster than standard SD (ICLR 2026)                                                    |
-| [IceCache](https://arxiv.org/abs/2604.10539)                         | 2026 | Semantic clustering for KV pages; 99% accuracy at 25% token budget                                                                |
-| [Can I Buy Your KV Cache?](https://arxiv.org/abs/2606.13361)         | 2026 | KV cache marketplace: publishers precompute, agents load instead of prefill; 9-50x cheaper compute on Qwen3-4B                    |
-| [LMCache](https://arxiv.org/abs/2510.09665)                          | 2025 | KV cache across GPU/CPU/disk/network; up to 15x throughput with vLLM                                                              |
-| [KV-Fold](https://arxiv.org/abs/2605.12471)                          | 2026 | One-step KV-cache recurrence; training-free long-context inference                                                                |
-| [Thin Keys, Full Values](https://arxiv.org/abs/2603.04427)           | 2026 | SVD-based key-cache compression; up to 16x combined with GQA + quantization                                                       |
-| [Make Each Token Count](https://arxiv.org/abs/2605.09649)            | 2026 | Learnable retention gates for KV eviction that improve long-context accuracy                                                      |
-| [Meta-Soft](https://arxiv.org/abs/2605.22337)                        | 2026 | Composable meta-tokens for context-preserving KV cache compression                                                                |
-| [KeepKV](https://arxiv.org/abs/2504.09936)                           | 2025 | Adaptive lossless merging; 2x+ throughput at 10% KV budget                                                                        |
-| [FreeKV](https://arxiv.org/abs/2505.13109)                           | 2025 | Training-free speculative KV retrieval; up to 13x speedup, near-lossless                                                          |
-| [SmallKV](https://arxiv.org/abs/2508.02751)                          | 2025 | Small-model-assisted eviction compensation; 1.75-2.56x higher throughput                                                          |
-| [Semantic Caching (Microsoft)](https://arxiv.org/abs/2508.07675)     | 2025 | Optimal semantic cache is NP-hard; Reverse Greedy + bandit learning                                                               |
-| [SpecFormer](https://arxiv.org/abs/2511.20340)                       | 2025 | Lossless non-autoregressive drafting that holds up under large-batch serving                                                      |
-| [LaProx](https://arxiv.org/abs/2605.07234)                           | 2026 | Output-aware, layer-wise KV eviction modeling attention×value interaction; beats prior eviction across 19 LongBench/NIAH datasets |
-| [Continuous Semantic Caching](https://arxiv.org/abs/2604.20021)      | 2026 | Theory for semantic caching in continuous embedding space; dynamic ε-net + kernel ridge regression                                |
-| [Learning to Draft (LTD)](https://arxiv.org/abs/2603.01639)          | 2026 | RL co-adapts draft+verify policies to optimize true throughput, not acceptance length (ICLR 2026)                                 |
-| [DDTree (Block Diffusion)](https://arxiv.org/abs/2604.12989)         | 2026 | Block-diffusion draft tree for speculative decoding; outperforms EAGLE-3 at matched node budget                                   |
-| [Graft](https://arxiv.org/abs/2605.20104)                            | 2026 | Training-free prune-then-retrieve framework for speculative decoding draft trees; 5.41× speedup, 21.8% over EAGLE-3 on Qwen3-235B |
+| Paper                                                                | Year | Key Result                                                                                                                               |
+| -------------------------------------------------------------------- | ---- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| [PagedAttention (vLLM)](https://arxiv.org/abs/2309.06180)            | 2023 | Near-zero KV cache waste                                                                                                                 |
+| [RadixAttention (SGLang)](https://arxiv.org/abs/2312.07104)          | 2023 | Auto KV cache reuse                                                                                                                      |
+| [KV Cache Survey (2026)](https://arxiv.org/abs/2603.20397)           | 2026 | Comprehensive techniques survey                                                                                                          |
+| [VectorQ Semantic Caching](https://arxiv.org/abs/2502.03771)         | 2025 | Up to 100x latency reduction                                                                                                             |
+| [KV-Compress](https://arxiv.org/abs/2410.00161)                      | 2024 | Variable-head-rate compression                                                                                                           |
+| [vAttention](https://arxiv.org/abs/2405.04437)                       | 2024 | 1.99x throughput over vLLM                                                                                                               |
+| [LazyLLM](https://arxiv.org/abs/2407.14057)                          | 2024 | Dynamic token pruning at prefill                                                                                                         |
+| [SlimInfer](https://arxiv.org/abs/2508.06447)                        | 2025 | 1.88x latency reduction                                                                                                                  |
+| [Mirror Speculative Decoding](https://arxiv.org/abs/2510.13161)      | 2025 | Breaks serial barrier                                                                                                                    |
+| [LongSpec](https://arxiv.org/abs/2502.17421)                         | 2025 | Constant memory speculative decoding                                                                                                     |
+| [Speculative Speculative Decoding](https://arxiv.org/abs/2603.03251) | 2026 | Parallelizes speculation+verification; 30% faster than standard SD (ICLR 2026)                                                           |
+| [IceCache](https://arxiv.org/abs/2604.10539)                         | 2026 | Semantic clustering for KV pages; 99% accuracy at 25% token budget                                                                       |
+| [Can I Buy Your KV Cache?](https://arxiv.org/abs/2606.13361)         | 2026 | KV cache marketplace: publishers precompute, agents load instead of prefill; 9-50x cheaper compute on Qwen3-4B                           |
+| [LMCache](https://arxiv.org/abs/2510.09665)                          | 2025 | KV cache across GPU/CPU/disk/network; up to 15x throughput with vLLM                                                                     |
+| [KV-Fold](https://arxiv.org/abs/2605.12471)                          | 2026 | One-step KV-cache recurrence; training-free long-context inference                                                                       |
+| [Thin Keys, Full Values](https://arxiv.org/abs/2603.04427)           | 2026 | SVD-based key-cache compression; up to 16x combined with GQA + quantization                                                              |
+| [Make Each Token Count](https://arxiv.org/abs/2605.09649)            | 2026 | Learnable retention gates for KV eviction that improve long-context accuracy                                                             |
+| [Meta-Soft](https://arxiv.org/abs/2605.22337)                        | 2026 | Composable meta-tokens for context-preserving KV cache compression                                                                       |
+| [KeepKV](https://arxiv.org/abs/2504.09936)                           | 2025 | Adaptive lossless merging; 2x+ throughput at 10% KV budget                                                                               |
+| [FreeKV](https://arxiv.org/abs/2505.13109)                           | 2025 | Training-free speculative KV retrieval; up to 13x speedup, near-lossless                                                                 |
+| [SmallKV](https://arxiv.org/abs/2508.02751)                          | 2025 | Small-model-assisted eviction compensation; 1.75-2.56x higher throughput                                                                 |
+| [Semantic Caching (Microsoft)](https://arxiv.org/abs/2508.07675)     | 2025 | Optimal semantic cache is NP-hard; Reverse Greedy + bandit learning                                                                      |
+| [SpecFormer](https://arxiv.org/abs/2511.20340)                       | 2025 | Lossless non-autoregressive drafting that holds up under large-batch serving                                                             |
+| [LaProx](https://arxiv.org/abs/2605.07234)                           | 2026 | Output-aware, layer-wise KV eviction modeling attention×value interaction; beats prior eviction across 19 LongBench/NIAH datasets        |
+| [Continuous Semantic Caching](https://arxiv.org/abs/2604.20021)      | 2026 | Theory for semantic caching in continuous embedding space; dynamic ε-net + kernel ridge regression                                       |
+| [Learning to Draft (LTD)](https://arxiv.org/abs/2603.01639)          | 2026 | RL co-adapts draft+verify policies to optimize true throughput, not acceptance length (ICLR 2026)                                        |
+| [DDTree (Block Diffusion)](https://arxiv.org/abs/2604.12989)         | 2026 | Block-diffusion draft tree for speculative decoding; outperforms EAGLE-3 at matched node budget                                          |
+| [Graft](https://arxiv.org/abs/2605.20104)                            | 2026 | Training-free prune-then-retrieve framework for speculative decoding draft trees; 5.41× speedup, 21.8% over EAGLE-3 on Qwen3-235B        |
+| [Still](https://arxiv.org/abs/2606.07878)                            | 2026 | Per-layer Perceiver compacts KV cache in one forward pass; 8×–200× compression; 8–22pt RULER gain over strongest baseline on Qwen/Gemma  |
+| [Information-Aware KV Cache](https://arxiv.org/abs/2606.26875)       | 2026 | Forward Influence metric shows high-uncertainty tokens have strongest distant-context impact; improves KV compression for long-reasoning |
+| [RDKV](https://arxiv.org/abs/2605.08317)                             | 2026 | Rate-distortion joint eviction+quantization; reaches 256K context on single A100 64 GB where Full KV fails                               |
+| [DSpark](https://arxiv.org/abs/2607.05147)                           | 2026 | Confidence-scheduled speculative decoding with adaptive, load-aware verification; high-throughput serving in large concurrent batches    |
 
 ### Prompt Optimization
 


### PR DESCRIPTION
Supersedes #31 (maintenance/2026-07-12) — incorporates its verified changes plus new July 19 findings.

## Provider Changes

**Anthropic**
- Updated Fable 5 pricing-table note: access was restored July 1, then extended through July 19, 2026; corrects PR #31's "July 13" date.
- Added **Claude Mythos 5** pricing row ($10/$50 per MTok) — confirmed on official Anthropic pricing page; same model as Fable 5 with safety classifiers removed, limited to ~150 Project Glasswing orgs. (PR #31 rejected this; now verified from primary source.)
- Added **Anthropic tokenizer note**: Claude Opus 4.7+, Sonnet 5, Fable 5, and Mythos 5 use a new tokenizer producing ~30% more tokens for the same text, raising effective cost per fixed input even though per-token rates are unchanged. Confirmed from official Anthropic pricing docs.

**OpenAI**
- Updated OpenAI Prompt Caching bullet: GPT-5.5 and earlier get 50% cached-input discount; **GPT-5.6+ gets 90% discount** with explicit cache breakpoints, 30-minute minimum TTL, and cache writes billed at 1.25× the input rate.
- Added **GPT-5.6 family** (GA July 9, 2026): Sol ($5/$30/MTok), Terra ($2.50/$15/MTok), Luna ($1/$6/MTok). Verified from OpenAI's own blog post and help center.
- Corrected GPT-5.5 cached-input discount from "90%" (erroneous) to "50%" in the pricing table.

**Google / DeepSeek / others**
- No new enacted changes found this run. Gemini 3 Flash ($0.50/$3) is still in preview. DeepSeek peak-hour pricing was reported only from a Reddit community post, not official docs — omitted.

## New Papers

**KV Cache & Inference table (4 additions):**

| Paper | arXiv | Key Result |
|---|---|---|
| Still | 2606.07878 | Per-layer Perceiver compacts KV in one forward pass; 8×–200× compression; 8–22pt RULER gain |
| Information-Aware KV Cache | 2606.26875 | Forward Influence metric: high-uncertainty tokens have strongest distant-context impact |
| RDKV | 2605.08317 | Rate-distortion joint eviction+quantization; 256K context on single A100 where Full KV fails |
| DSpark | 2607.05147 | Confidence-scheduled speculative decoding with adaptive, load-aware verification (Jul 2026) |

Still and Information-Aware KV were in PR #31. RDKV and DSpark are new this run. All four arXiv IDs verified via search against arxiv.org abstracts and Hugging Face Papers.

## New Tools

None added. Checked LiteLLM (v1.92.0, July 12), RouteLLM (accessible, 5.2k stars), LLMLingua (6.5k stars), DeepSpec/DSpark repo (active, 6.7k stars). No new tools cleared the traction/specificity bar.

## New Strategies

None added.

## Dead Links

Checked ~10 links via WebFetch. The following returned 403 (bot-blocking, not confirmed dead):
- `openrouter.ai/docs/quickstart`
- `ai.google.dev/gemini-api/docs/pricing`
- `arxiv.org/abs/*` (all arxiv links 403 from bot; verified via search instead)

None confirmed dead. No removals made.

## Checked but Rejected

- **DeepSeek peak-hour pricing**: Announced June 30 (TechNode) for mid-July, sourced only from a Reddit post — not in official DeepSeek changelog. Omitted per CLAUDE.md.
- **Gemini 3 Flash Preview** ($0.50/$3): Still in preview as of July 19; GA date not confirmed. Omitted.
- **Anthropic Managed Agents $0.08/session-hour**: Session runtime cost (not token-based); outside the token optimization focus of this list.
- **qolca.org guide (PR #34)** and **agent-cost-guardrails (PR #33)**: Not reviewed here — those are contributor PRs for the repo owner to evaluate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtaGyYagzNdUvJK3DSDRU7)_