### PR TITLE
maintenance 2026-07-19: PR/issue review + verified Anthropic tokenizer caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ The [accessibility tree](https://developer.mozilla.org/en-US/docs/Glossary/Acces
 | Gemini 3.5 Flash      | $1.50       | $9.00        | Launched May 19, 2026; 1M context window                                                                                                     |
 | Gemini 2.5 Flash-Lite | $0.10       | $0.40        | Budget option                                                                                                                                |
 
+**Tokenizer note (Anthropic):** Claude Opus 4.7+, Sonnet 5, and Fable 5 use a newer tokenizer that produces roughly 30% more tokens for the same text; per-token prices are unchanged, so the effective cost of a fixed input rises proportionally (Sonnet 4.6 and earlier keep the previous tokenizer). Benchmark your real workload before assuming a newer model lowers cost — confirmed on Anthropic's official pricing docs (already linked under Provider Pricing Pages above).
+
 ## Prompt Engineering for Efficiency
 
 ### Official Guides


### PR DESCRIPTION
Consolidated maintenance + review run for 2026-07-19. **Supersedes the open draft #35** (see "Why this supersedes #35" below). Branch name follows this run's assigned working branch rather than `maintenance/YYYY-MM-DD`.

Guiding principle this run: **add only what verifies against an authoritative primary source.** This environment's web-search layer returns confirmatory-looking content for almost anything, so search-only corroboration was treated as insufficient per CLAUDE.md Hard Rule 2.

## Added (1)

- **Anthropic tokenizer caveat** in the Pricing Comparison section. Claude Opus 4.7+, Sonnet 5, and Fable 5 use a newer tokenizer producing ~30% more tokens for the same text; per-token prices are unchanged, so effective cost per fixed input rises proportionally. **Verified directly against the official Anthropic pricing docs** (`platform.claude.com/docs/en/about-claude/pricing`), which state it verbatim. Genuinely on-theme (it changes real token cost) and actionable ("benchmark before assuming a model upgrade saves money"). No new link added — the pricing page is already linked under Provider Pricing Pages, so this avoids an awesome-lint duplicate-link error.

## Checked but NOT added, with reasons

**Provider / pricing**
- **Claude Mythos 5** — The official pricing page does list it, but as "limited availability" (Project Glasswing) at the *same* $10/$50 as Fable 5, so it adds no cost-optimization signal to a comparison table. The notable framing in #35 ("safety classifiers removed", "~150 orgs") appears **only in third-party blogs, not in Anthropic's docs** — unverifiable, so must not be stated as fact. Rejected by prior runs #23 and #31 for the same reason.
- **GPT-5.6 Sol/Terra/Luna pricing rows** — GA (July 9) is reported by mainstream press, but I could not confirm the exact per-MTok prices or the cache-write multiplier against a primary OpenAI page (all `openai.com` / `developers.openai.com` pages 403 in this environment). Deferred until the numbers can be confirmed in a browser.
- **OpenAI cached-input discount rewrite (50% vs 90%)** — Secondary sources conflict (some report GPT-5.5 cached reads at 90%, #35 changes it to 50%). No primary confirmation reachable; left the existing OpenAI caching text untouched rather than churn it on unverified numbers.
- **DeepSeek V4 off-peak/peak-hour pricing** — Announced, not confirmed enacted on DeepSeek's own pricing page. Omitted per Hard Rule 2 (same call as #28/#31).
- **Anthropic Managed Agents ($0.08/session-hour), code-execution hours, data-residency 1.1x** — Real (seen on the pricing page) but not token-based cost optimization; out of scope for this list.

**Papers (4, all deferred)**
- **Still (2606.07878), Information-Aware KV Cache (2606.26875), RDKV (2605.08317), DSpark (2607.05147)** — `arxiv.org`, the `export.arxiv.org` Atom API, **and** the Semantic Scholar API all return 403 in this environment, so no structured/primary confirmation of these IDs was obtainable. The only available corroboration is the web-search layer, which is unreliable here. Per Hard Rule 2 ("never add unverifiable or future-dated IDs"), these are deferred, not added. (DSpark is additionally off-theme — speculative decoding is throughput/latency, not token count.) A maintainer with browser access can verify the three KV-cache IDs and add them directly.

**Contributor PRs (all 4 fail the quality bar — details in each PR thread)**
- **#30 traceburn** — on-topic + MIT, but 2 stars, single-author, ~2 weeks old. Below the traction bar.
- **#32 KV Cache Store** — the PR's link (`kvcachestore/kvcdn`) 404s; the real repo (`kvcdn-cli`) has ~6 stars, is **source-available (not open-source)**, and fronts a paid hosted service.
- **#33 agent-cost-guardrails** — 0 stars, single-author, a single placeholder 0.1.0 on PyPI/npm. Textbook low-traction self-promotion (already labeled `slop`).
- **#34 Qolca guide** — self-promotional single-company blog by a disclosed affiliate; the post is bot-blocked/unindexed so its substance can't be verified (already labeled `slop`).

## Why this supersedes #35

#35 (also dated 2026-07-19) re-introduced **Mythos 5** and the **GPT-5.6 pricing rows** — both previously rejected by #23/#28/#31 as restricted/preview — and asserted them plus four arXiv IDs as "verified from primary source," when the reachable primary sources here don't support the load-bearing details. This PR keeps only the one claim that survives authoritative verification (the tokenizer caveat) and documents the rest as deferred. Closing #35 as superseded to avoid stacking near-duplicate maintenance PRs.

## Open issues

None.

## Verification

- `npx prettier --write README.md` → unchanged (already format-clean)
- `npx awesome-lint` → only the known `awesome-github` false positive (the local mirror's git remote isn't a github.com URL; passes clean against the real GitHub URL, as documented in prior runs). No duplicate-link or list-format errors.


---
_Generated by [Claude Code](https://claude.ai/code/session_017GqE8ngusH9nFTTKyEPMRZ)_