### PR TITLE
Add TierDecay to Model Routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Route simple tasks to cheaper models. 80% of typical LLM calls don't need the mo
 - [Portkey AI Gateway](https://github.com/Portkey-AI/gateway) - Open-source AI gateway routing to 1,600+ LLMs with guardrails, caching, and load balancing. Acquired by Palo Alto Networks (May 2026); gateway remains open-source under Apache 2.0. ![Stars](https://img.shields.io/github/stars/Portkey-AI/gateway)
 - [OpenRouter](https://openrouter.ai/docs/quickstart) - Unified API for 300+ models with [auto-router](https://openrouter.ai/docs/guides/routing/routers/auto-router).
 - [Martian Router](https://route.withmartian.com/) - Patent-pending; cuts costs 20-97% via "Model Mapping".
+- [TierDecay](https://github.com/alebgl77/tierdecay) - Self-distilling tier router for AI coding CLIs; solves each task class once at an expensive tier, distills it into a low-tier playbook entry, then decays the class's default tier down (T3→T2→T1) via a ledger of predicted-vs-executed tiers. Cost drops toward the cheap tier as recurring classes decay. ![Stars](https://img.shields.io/github/stars/alebgl77/tierdecay)
 
 ### Curated Lists
 


### PR DESCRIPTION
Adds **TierDecay** to the **Model Routing** section (after Martian Router).

- **Repo:** https://github.com/alebgl77/tierdecay (MIT)
- **Cost mechanism (by model selection, not token manipulation):** a cold-start rubric routes each task across tiers; a ledger of predicted-vs-executed tiers overrides it as evidence accrues. When an expensive tier solves a recurring problem class, the decision is distilled into a ≤15-line playbook entry, and subsequent occurrences are probed one tier cheaper until the class's default tier drops for good (T3→T2→T1). The marginal cost of each recurring class decays toward the cheap-tier price.
- **Scope fit:** same section as RouteLLM / LiteLLM / Martian — routing across model tiers to trade cost for quality — specialized for terminal coding agents (Claude Code, Codex/AGENTS.md, Cursor, Gemini CLI, Aider, Cline, Goose, Windsurf).

Note on the "quantified gains" guideline: TierDecay deliberately ships no benchmark numbers (its stated method is that users publish their own ledger). The cost reduction is mechanical — recurring classes execute at progressively cheaper tiers — rather than a claimed percentage, so I've described the mechanism instead of inventing a figure. Format matches the section (stars badge included).