### PR TITLE
Add PromptSpend to Live Pricing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ The [accessibility tree](https://developer.mozilla.org/en-US/docs/Glossary/Acces
 ### Live Pricing Tools
 
 - [Price Per Token](https://pricepertoken.com/) - Daily-updated, 300+ models.
+- [PromptSpend](https://promptspend.com/) - Open-source LLM cost calculator with a free, keyless pricing API; every price links to its source and last-verified date instead of standing alone. ![Stars](https://img.shields.io/github/stars/AndrewAvery7/promptspend)
 - [Artificial Analysis Calculator](https://artificialanalysis.ai/tools/llm-price-calculator) - Free calculator, 100+ models.
 - [Artificial Analysis Leaderboard](https://artificialanalysis.ai/leaderboards/models) - Quality + price + speed.
 - [Simon Willison's LLM Prices](https://tools.simonwillison.net/llm-prices) - Interactive calculator.


### PR DESCRIPTION
Adds PromptSpend to the Live Pricing Tools list under Pricing Comparison.

PromptSpend is an open-source LLM cost calculator with a free, keyless pricing API. Every price carries a source link and a last-verified date instead of standing alone, which makes it a citable, complementary entry alongside the cost-tracking tools already in this list.

Per CONTRIBUTING.md, the entry is placed alphabetically (after Price Per Token, before Simon Willison's LLM Prices) -- the surrounding list has drifted out of alphabetical order and I did not reorder the rest.

One entry, one PR, per the contributing guide.