### PR TITLE
Add Kingy.ai AI API Price Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ The [accessibility tree](https://developer.mozilla.org/en-US/docs/Glossary/Acces
 - [Artificial Analysis Leaderboard](https://artificialanalysis.ai/leaderboards/models) - Quality + price + speed.
 - [Simon Willison's LLM Prices](https://tools.simonwillison.net/llm-prices) - Interactive calculator.
 - [Helicone LLM Cost Comparison](https://www.helicone.ai/llm-cost) - 300+ model calculator.
+- [Kingy.ai AI API Price Index](https://kingy.ai/kapi/price-index/) - Versioned, source-audited prices for exact API offerings; preserves seller, route, region, service tier, billing mode, cache treatment, and context band, with CC BY JSON/CSV and SHA-256 manifests.
 - [CostGoat](https://costgoat.com/compare/llm-api) - 302+ APIs from 10+ providers.
 - [Langtail](https://langtail.com/llm-price-comparison) - Side-by-side comparison.
 - [WhatLLM](https://whatllm.org/) - 256 models, 43+ providers, weekly updates.


### PR DESCRIPTION
Adds the Kingy.ai AI API Price Index to Live Pricing Tools. The current immutable release covers 40 exact offerings and 218 price components across eight providers. It preserves seller, route, endpoint, region, service tier, billing mode, cache treatment, and context band instead of blending them into a model-name price, and provides CC BY JSON/CSV with official-source provenance and SHA-256 manifests.\n\nDisclosure: I built and maintain this resource at Kingy.ai. The linked page and downloads are free; there is no affiliate relationship.